### PR TITLE
Handle non-JSON responses from 1nce API

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ince-api (0.2.0)
+    ince-api (0.3.1)
       base64 (~> 0.1)
       net-http (~> 0.2)
       openssl
@@ -10,44 +10,51 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.8.0)
-      public_suffix (>= 2.0.2, < 5.0)
-    base64 (0.2.0)
+    addressable (2.8.9)
+      public_suffix (>= 2.0.2, < 8.0)
+    base64 (0.3.0)
+    bigdecimal (4.0.1)
     coderay (1.1.3)
-    crack (0.4.5)
+    crack (1.0.1)
+      bigdecimal
       rexml
-    diff-lcs (1.4.4)
-    hashdiff (1.0.1)
-    method_source (1.0.0)
-    net-http (0.4.1)
-      uri
-    openssl (3.2.0)
-    pry (0.14.1)
+    diff-lcs (1.6.2)
+    hashdiff (1.2.1)
+    io-console (0.8.2)
+    method_source (1.1.0)
+    net-http (0.9.1)
+      uri (>= 0.11.1)
+    openssl (4.0.1)
+    pry (0.16.0)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    public_suffix (4.0.6)
-    rexml (3.2.5)
-    rspec (3.10.0)
-      rspec-core (~> 3.10.0)
-      rspec-expectations (~> 3.10.0)
-      rspec-mocks (~> 3.10.0)
-    rspec-core (3.10.1)
-      rspec-support (~> 3.10.0)
-    rspec-expectations (3.10.1)
+      reline (>= 0.6.0)
+    public_suffix (7.0.5)
+    reline (0.6.3)
+      io-console (~> 0.5)
+    rexml (3.4.4)
+    rspec (3.13.2)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
+    rspec-core (3.13.6)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.5)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.10.0)
-    rspec-mocks (3.10.2)
+      rspec-support (~> 3.13.0)
+    rspec-mocks (3.13.8)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.10.0)
-    rspec-support (3.10.3)
-    uri (0.13.0)
-    vcr (6.0.0)
-    webmock (3.14.0)
+      rspec-support (~> 3.13.0)
+    rspec-support (3.13.7)
+    uri (0.13.3)
+    vcr (6.4.0)
+    webmock (3.26.1)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
 
 PLATFORMS
+  arm64-darwin-25
   ruby
 
 DEPENDENCIES
@@ -57,5 +64,31 @@ DEPENDENCIES
   vcr (~> 6.0)
   webmock (~> 3.14)
 
+CHECKSUMS
+  addressable (2.8.9) sha256=cc154fcbe689711808a43601dee7b980238ce54368d23e127421753e46895485
+  base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
+  bigdecimal (4.0.1) sha256=8b07d3d065a9f921c80ceaea7c9d4ae596697295b584c296fe599dd0ad01c4a7
+  coderay (1.1.3) sha256=dc530018a4684512f8f38143cd2a096c9f02a1fc2459edcfe534787a7fc77d4b
+  crack (1.0.1) sha256=ff4a10390cd31d66440b7524eb1841874db86201d5b70032028553130b6d4c7e
+  diff-lcs (1.6.2) sha256=9ae0d2cba7d4df3075fe8cd8602a8604993efc0dfa934cff568969efb1909962
+  hashdiff (1.2.1) sha256=9c079dbc513dfc8833ab59c0c2d8f230fa28499cc5efb4b8dd276cf931457cd1
+  ince-api (0.3.1)
+  io-console (0.8.2) sha256=d6e3ae7a7cc7574f4b8893b4fca2162e57a825b223a177b7afa236c5ef9814cc
+  method_source (1.1.0) sha256=181301c9c45b731b4769bc81e8860e72f9161ad7d66dd99103c9ab84f560f5c5
+  net-http (0.9.1) sha256=25ba0b67c63e89df626ed8fac771d0ad24ad151a858af2cc8e6a716ca4336996
+  openssl (4.0.1) sha256=e27974136b7b02894a1bce46c5397ee889afafe704a839446b54dc81cb9c5f7d
+  pry (0.16.0) sha256=d76c69065698ed1f85e717bd33d7942c38a50868f6b0673c636192b3d1b6054e
+  public_suffix (7.0.5) sha256=1a8bb08f1bbea19228d3bed6e5ed908d1cb4f7c2726d18bd9cadf60bc676f623
+  reline (0.6.3) sha256=1198b04973565b36ec0f11542ab3f5cfeeec34823f4e54cebde90968092b1835
+  rexml (3.4.4) sha256=19e0a2c3425dfbf2d4fc1189747bdb2f849b6c5e74180401b15734bc97b5d142
+  rspec (3.13.2) sha256=206284a08ad798e61f86d7ca3e376718d52c0bc944626b2349266f239f820587
+  rspec-core (3.13.6) sha256=a8823c6411667b60a8bca135364351dda34cd55e44ff94c4be4633b37d828b2d
+  rspec-expectations (3.13.5) sha256=33a4d3a1d95060aea4c94e9f237030a8f9eae5615e9bd85718fe3a09e4b58836
+  rspec-mocks (3.13.8) sha256=086ad3d3d17533f4237643de0b5c42f04b66348c28bf6b9c2d3f4a3b01af1d47
+  rspec-support (3.13.7) sha256=0640e5570872aafefd79867901deeeeb40b0c9875a36b983d85f54fb7381c47c
+  uri (0.13.3) sha256=ed4565c15b73602437a45d6dccb326fefcad0cc8c83794473af0b0439b2e1ea7
+  vcr (6.4.0) sha256=077ac92cc16efc5904eb90492a18153b5e6ca5398046d8a249a7c96a9ea24ae6
+  webmock (3.26.1) sha256=4f696fb57c90a827c20aadb2d4f9058bbff10f7f043bd0d4c3f58791143b1cd7
+
 BUNDLED WITH
-   2.1.4
+  4.0.7

--- a/ince-api.gemspec
+++ b/ince-api.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'ince-api'
-  s.version     = '0.3.0'
+  s.version     = '0.3.1'
   s.summary     = "1nce API wrapper"
   s.description = "A simple wrapper for 1nce API"
   s.authors     = ["Stanislaw Zawadzki"]

--- a/ince-api.gemspec
+++ b/ince-api.gemspec
@@ -1,24 +1,25 @@
+# frozen_string_literal: true
+
 Gem::Specification.new do |s|
   s.name        = 'ince-api'
   s.version     = '0.3.1'
-  s.summary     = "1nce API wrapper"
-  s.description = "A simple wrapper for 1nce API"
-  s.authors     = ["Stanislaw Zawadzki"]
+  s.summary     = '1nce API wrapper'
+  s.description = 'A simple wrapper for 1nce API'
+  s.authors     = ['Stanislaw Zawadzki']
   s.email       = 'st.zawadzki@gmail.com'
   s.homepage    = 'https://rubygems.org/gems/ince-api'
-  s.license       = 'MIT'
+  s.license = 'MIT'
 
   s.files = `git ls-files`.split($INPUT_RECORD_SEPARATOR)
   s.test_files    = s.files.grep(%r{^(test|spec|features)/})
   s.require_paths = ['lib']
   s.license       = 'MIT'
-  s.add_dependency 'uri', '~> 0.13'
+  s.add_dependency 'base64', '~> 0.1'
   s.add_dependency 'net-http', '~> 0.2'
   s.add_dependency 'openssl'
-  s.add_dependency 'base64', '~> 0.1'
+  s.add_dependency 'uri', '~> 0.13'
   s.add_development_dependency 'pry', '~> 0.13'
   s.add_development_dependency 'rspec', '~> 3.9'
-  s.add_development_dependency 'webmock', '~> 3.14'
   s.add_development_dependency 'vcr', '~> 6.0'
+  s.add_development_dependency 'webmock', '~> 3.14'
 end
-

--- a/lib/ince-api.rb
+++ b/lib/ince-api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'uri'
 require 'net/http'
 require 'openssl'

--- a/lib/ince_api/create_access_token.rb
+++ b/lib/ince_api/create_access_token.rb
@@ -12,6 +12,8 @@ module InceApi
     def create_token
       response = connection.request(request)
       JSON.parse(response.body)
+    rescue JSON::ParserError
+      {'status_code' => response.code.to_i, 'error_message' => "Invalid JSON response: #{response.body[0..200]}"}
     end
 
     def request

--- a/lib/ince_api/create_access_token.rb
+++ b/lib/ince_api/create_access_token.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'json'
 
 module InceApi
@@ -7,21 +9,21 @@ module InceApi
       @password = password
     end
 
-    URL = URI("https://api.1nce.com/management-api/oauth/token")
+    URL = URI('https://api.1nce.com/management-api/oauth/token')
 
     def create_token
       response = connection.request(request)
       JSON.parse(response.body)
     rescue JSON::ParserError
-      {'status_code' => response.code.to_i, 'error_message' => "Invalid JSON response: #{response.body[0..200]}"}
+      { 'status_code' => response.code.to_i, 'error_message' => "Invalid JSON response: #{response.body[0..200]}" }
     end
 
     def request
       Net::HTTP::Post.new(URL).tap do |request|
-        request["Accept"] = 'application/json'
-        request["Content-Type"] = 'application/x-www-form-urlencoded'
-        request["Authorization"] = "Basic #{encoded_credentials}"
-        request.body = "grant_type=client_credentials"
+        request['Accept'] = 'application/json'
+        request['Content-Type'] = 'application/x-www-form-urlencoded'
+        request['Authorization'] = "Basic #{encoded_credentials}"
+        request.body = 'grant_type=client_credentials'
       end
     end
 

--- a/lib/ince_api/create_sms.rb
+++ b/lib/ince_api/create_sms.rb
@@ -1,6 +1,8 @@
+# frozen_string_literal: true
+
 module InceApi
   class CreateSms
-    def initialize(access_token:, iccid:, params:{})
+    def initialize(access_token:, iccid:, params: {})
       @access_token = access_token
       @iccid = iccid
       @params = params
@@ -8,12 +10,17 @@ module InceApi
 
     def send
       response = connection.request(request)
-      response.code.to_i == 201 ? allowed_params.merge(status: 'OK') : { status: 'FAILED', error_code: response.code.to_i}
+      if response.code.to_i == 201
+        allowed_params.merge(status: 'OK')
+      else
+        { status: 'FAILED',
+          error_code: response.code.to_i }
+      end
     end
 
     private
 
-    ALLOWED_KEYS = %i(source_address payload udh dcs source_address_type expiry_date)
+    ALLOWED_KEYS = %i[source_address payload udh dcs source_address_type expiry_date].freeze
     def allowed_params
       @params.slice(*ALLOWED_KEYS)
     end
@@ -31,8 +38,8 @@ module InceApi
     def request
       Net::HTTP::Post.new(url).tap do |request|
         request.body = allowed_params.to_json
-        request["Accept"] = 'application/json'
-        request["Content-Type"] = 'application/json;charset=UTF-8'
+        request['Accept'] = 'application/json'
+        request['Content-Type'] = 'application/json;charset=UTF-8'
         request['Authorization'] = "Bearer #{@access_token}"
       end
     end

--- a/lib/ince_api/get_sim.rb
+++ b/lib/ince_api/get_sim.rb
@@ -7,11 +7,13 @@ module InceApi
 
     def sim
       response = connection.request(request)
-      if response.body != ''
-        JSON.parse(response.body)
-      else
+      if response.body.to_s.empty?
         {'status_code' => 404, 'error_message' => 'SIM with ICCID not found'}
+      else
+        JSON.parse(response.body)
       end
+    rescue JSON::ParserError
+      {'status_code' => response.code.to_i, 'error_message' => "Invalid JSON response: #{response.body[0..200]}"}
     end
 
     private

--- a/lib/ince_api/get_sim.rb
+++ b/lib/ince_api/get_sim.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module InceApi
   class GetSim
     def initialize(access_token:, iccid:)
@@ -8,12 +10,12 @@ module InceApi
     def sim
       response = connection.request(request)
       if response.body.to_s.empty?
-        {'status_code' => 404, 'error_message' => 'SIM with ICCID not found'}
+        { 'status_code' => 404, 'error_message' => 'SIM with ICCID not found' }
       else
         JSON.parse(response.body)
       end
     rescue JSON::ParserError
-      {'status_code' => response.code.to_i, 'error_message' => "Invalid JSON response: #{response.body[0..200]}"}
+      { 'status_code' => response.code.to_i, 'error_message' => "Invalid JSON response: #{response.body[0..200]}" }
     end
 
     private
@@ -30,7 +32,7 @@ module InceApi
 
     def request
       Net::HTTP::Get.new(url).tap do |request|
-        request["Accept"] = 'application/json'
+        request['Accept'] = 'application/json'
         request['Authorization'] = "Bearer #{@access_token}"
       end
     end

--- a/lib/ince_api/get_sim_connectivity.rb
+++ b/lib/ince_api/get_sim_connectivity.rb
@@ -7,11 +7,13 @@ module InceApi
 
     def sim
       response = connection.request(request)
-      if response.body != ''
-        JSON.parse(response.body)
-      else
+      if response.body.to_s.empty?
         {'status_code' => 404, 'error_message' => 'SIM with ICCID not found'}
+      else
+        JSON.parse(response.body)
       end
+    rescue JSON::ParserError
+      {'status_code' => response.code.to_i, 'error_message' => "Invalid JSON response: #{response.body[0..200]}"}
     end
 
     private

--- a/lib/ince_api/get_sim_connectivity.rb
+++ b/lib/ince_api/get_sim_connectivity.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module InceApi
   class GetSimConnectivity
     def initialize(access_token:, iccid:)
@@ -8,12 +10,12 @@ module InceApi
     def sim
       response = connection.request(request)
       if response.body.to_s.empty?
-        {'status_code' => 404, 'error_message' => 'SIM with ICCID not found'}
+        { 'status_code' => 404, 'error_message' => 'SIM with ICCID not found' }
       else
         JSON.parse(response.body)
       end
     rescue JSON::ParserError
-      {'status_code' => response.code.to_i, 'error_message' => "Invalid JSON response: #{response.body[0..200]}"}
+      { 'status_code' => response.code.to_i, 'error_message' => "Invalid JSON response: #{response.body[0..200]}" }
     end
 
     private
@@ -30,7 +32,7 @@ module InceApi
 
     def request
       Net::HTTP::Get.new(url).tap do |request|
-        request["Accept"] = 'application/json'
+        request['Accept'] = 'application/json'
         request['Authorization'] = "Bearer #{@access_token}"
       end
     end

--- a/lib/ince_api/get_sim_data_quota.rb
+++ b/lib/ince_api/get_sim_data_quota.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module InceApi
   class GetSimDataQuota
     def initialize(access_token:, iccid:)
@@ -8,12 +10,12 @@ module InceApi
     def sim_status
       response = connection.request(request)
       if response.body.to_s.empty?
-        {'status_code' => 404, 'error_message' => 'SIM with ICCID not found'}
+        { 'status_code' => 404, 'error_message' => 'SIM with ICCID not found' }
       else
         JSON.parse(response.body)
       end
     rescue JSON::ParserError
-      {'status_code' => response.code.to_i, 'error_message' => "Invalid JSON response: #{response.body[0..200]}"}
+      { 'status_code' => response.code.to_i, 'error_message' => "Invalid JSON response: #{response.body[0..200]}" }
     end
 
     private
@@ -30,7 +32,7 @@ module InceApi
 
     def request
       Net::HTTP::Get.new(url).tap do |request|
-        request["Accept"] = 'application/json'
+        request['Accept'] = 'application/json'
         request['Authorization'] = "Bearer #{@access_token}"
       end
     end

--- a/lib/ince_api/get_sim_data_quota.rb
+++ b/lib/ince_api/get_sim_data_quota.rb
@@ -7,11 +7,13 @@ module InceApi
 
     def sim_status
       response = connection.request(request)
-      if response.body != ''
-        JSON.parse(response.body)
-      else
+      if response.body.to_s.empty?
         {'status_code' => 404, 'error_message' => 'SIM with ICCID not found'}
+      else
+        JSON.parse(response.body)
       end
+    rescue JSON::ParserError
+      {'status_code' => response.code.to_i, 'error_message' => "Invalid JSON response: #{response.body[0..200]}"}
     end
 
     private

--- a/lib/ince_api/get_sim_sms_quota.rb
+++ b/lib/ince_api/get_sim_sms_quota.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module InceApi
   class GetSimSmsQuota
     def initialize(access_token:, iccid:)
@@ -8,12 +10,12 @@ module InceApi
     def sim_status
       response = connection.request(request)
       if response.body.to_s.empty?
-        {'status_code' => 404, 'error_message' => 'SIM with ICCID not found'}
+        { 'status_code' => 404, 'error_message' => 'SIM with ICCID not found' }
       else
         JSON.parse(response.body)
       end
     rescue JSON::ParserError
-      {'status_code' => response.code.to_i, 'error_message' => "Invalid JSON response: #{response.body[0..200]}"}
+      { 'status_code' => response.code.to_i, 'error_message' => "Invalid JSON response: #{response.body[0..200]}" }
     end
 
     private
@@ -30,7 +32,7 @@ module InceApi
 
     def request
       Net::HTTP::Get.new(url).tap do |request|
-        request["Accept"] = 'application/json'
+        request['Accept'] = 'application/json'
         request['Authorization'] = "Bearer #{@access_token}"
       end
     end

--- a/lib/ince_api/get_sim_sms_quota.rb
+++ b/lib/ince_api/get_sim_sms_quota.rb
@@ -7,11 +7,13 @@ module InceApi
 
     def sim_status
       response = connection.request(request)
-      if response.body != ''
-        JSON.parse(response.body)
-      else
+      if response.body.to_s.empty?
         {'status_code' => 404, 'error_message' => 'SIM with ICCID not found'}
+      else
+        JSON.parse(response.body)
       end
+    rescue JSON::ParserError
+      {'status_code' => response.code.to_i, 'error_message' => "Invalid JSON response: #{response.body[0..200]}"}
     end
 
     private

--- a/lib/ince_api/get_sim_status.rb
+++ b/lib/ince_api/get_sim_status.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module InceApi
   class GetSimStatus
     def initialize(access_token:, iccid:)
@@ -8,12 +10,12 @@ module InceApi
     def sim_status
       response = connection.request(request)
       if response.body.to_s.empty?
-        {'status_code' => 404, 'error_message' => 'SIM with ICCID not found'}
+        { 'status_code' => 404, 'error_message' => 'SIM with ICCID not found' }
       else
         JSON.parse(response.body)
       end
     rescue JSON::ParserError
-      {'status_code' => response.code.to_i, 'error_message' => "Invalid JSON response: #{response.body[0..200]}"}
+      { 'status_code' => response.code.to_i, 'error_message' => "Invalid JSON response: #{response.body[0..200]}" }
     end
 
     private
@@ -30,7 +32,7 @@ module InceApi
 
     def request
       Net::HTTP::Get.new(url).tap do |request|
-        request["Accept"] = 'application/json'
+        request['Accept'] = 'application/json'
         request['Authorization'] = "Bearer #{@access_token}"
       end
     end

--- a/lib/ince_api/get_sim_status.rb
+++ b/lib/ince_api/get_sim_status.rb
@@ -7,11 +7,13 @@ module InceApi
 
     def sim_status
       response = connection.request(request)
-      if response.body != ''
-        JSON.parse(response.body)
-      else
+      if response.body.to_s.empty?
         {'status_code' => 404, 'error_message' => 'SIM with ICCID not found'}
+      else
+        JSON.parse(response.body)
       end
+    rescue JSON::ParserError
+      {'status_code' => response.code.to_i, 'error_message' => "Invalid JSON response: #{response.body[0..200]}"}
     end
 
     private

--- a/lib/ince_api/get_sim_usage.rb
+++ b/lib/ince_api/get_sim_usage.rb
@@ -8,11 +8,13 @@ module InceApi
 
     def sim_usage
       response = connection.request(request)
-      if response.body != ''
-        JSON.parse(response.body)
-      else
+      if response.body.to_s.empty?
         {'status_code' => 404, 'error_message' => 'SIM with ICCID not found'}
+      else
+        JSON.parse(response.body)
       end
+    rescue JSON::ParserError
+      {'status_code' => response.code.to_i, 'error_message' => "Invalid JSON response: #{response.body[0..200]}"}
     end
 
     private

--- a/lib/ince_api/get_sim_usage.rb
+++ b/lib/ince_api/get_sim_usage.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module InceApi
   class GetSimUsage
     def initialize(access_token:, iccid:, params: {})
@@ -9,17 +11,17 @@ module InceApi
     def sim_usage
       response = connection.request(request)
       if response.body.to_s.empty?
-        {'status_code' => 404, 'error_message' => 'SIM with ICCID not found'}
+        { 'status_code' => 404, 'error_message' => 'SIM with ICCID not found' }
       else
         JSON.parse(response.body)
       end
     rescue JSON::ParserError
-      {'status_code' => response.code.to_i, 'error_message' => "Invalid JSON response: #{response.body[0..200]}"}
+      { 'status_code' => response.code.to_i, 'error_message' => "Invalid JSON response: #{response.body[0..200]}" }
     end
 
     private
 
-    ALLOWED_KEYS = %i(start_dt end_dt)
+    ALLOWED_KEYS = %i[start_dt end_dt].freeze
     def params_query
       URI.encode_www_form @params.slice(*ALLOWED_KEYS)
     end
@@ -36,7 +38,7 @@ module InceApi
 
     def request
       Net::HTTP::Get.new(url).tap do |request|
-        request["Accept"] = 'application/json'
+        request['Accept'] = 'application/json'
         request['Authorization'] = "Bearer #{@access_token}"
       end
     end

--- a/lib/ince_api/get_sims.rb
+++ b/lib/ince_api/get_sims.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module InceApi
   class GetSims
     attr_reader :headers
@@ -13,12 +15,12 @@ module InceApi
 
       JSON.parse(response.body)
     rescue JSON::ParserError
-      {'status_code' => response.code.to_i, 'error_message' => "Invalid JSON response: #{response.body[0..200]}"}
+      { 'status_code' => response.code.to_i, 'error_message' => "Invalid JSON response: #{response.body[0..200]}" }
     end
 
     private
 
-    ALLOWED_KEYS = %i(page pageSize q sort)
+    ALLOWED_KEYS = %i[page pageSize q sort].freeze
     def params_query
       URI.encode_www_form @params.slice(*ALLOWED_KEYS)
     end
@@ -35,7 +37,7 @@ module InceApi
 
     def request
       Net::HTTP::Get.new(url).tap do |request|
-        request["Accept"] = 'application/json'
+        request['Accept'] = 'application/json'
         request['Authorization'] = "Bearer #{@access_token}"
       end
     end

--- a/lib/ince_api/get_sims.rb
+++ b/lib/ince_api/get_sims.rb
@@ -12,6 +12,8 @@ module InceApi
       @headers = response.each_header.to_h
 
       JSON.parse(response.body)
+    rescue JSON::ParserError
+      {'status_code' => response.code.to_i, 'error_message' => "Invalid JSON response: #{response.body[0..200]}"}
     end
 
     private

--- a/lib/ince_api/multiple_sims_configuration.rb
+++ b/lib/ince_api/multiple_sims_configuration.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module InceApi
   class MultipleSimsConfiguration
     def initialize(access_token:, changes_array: [])
@@ -7,19 +9,19 @@ module InceApi
 
     def update_many
       response = connection.request(request)
-      response.code.to_i == 201 ? { status: 'OK' } : { status: 'FAILED', error_code: response.code.to_i}
+      response.code.to_i == 201 ? { status: 'OK' } : { status: 'FAILED', error_code: response.code.to_i }
     end
 
     private
 
-    ALLOWED_KEYS = %i(iccid label imei_lock status)
+    ALLOWED_KEYS = %i[iccid label imei_lock status].freeze
     def body
-      @changes_array.select{|sim_params| !sim_params[:iccid].nil?}
-        .map{|sim_params| sim_params.slice(*ALLOWED_KEYS)}.to_json
+      @changes_array.reject { |sim_params| sim_params[:iccid].nil? }
+                    .map { |sim_params| sim_params.slice(*ALLOWED_KEYS) }.to_json
     end
 
     def url
-      @url ||= URI("https://api.1nce.com/management-api/v1/sims")
+      @url ||= URI('https://api.1nce.com/management-api/v1/sims')
     end
 
     def connection
@@ -31,8 +33,8 @@ module InceApi
     def request
       Net::HTTP::Post.new(url).tap do |request|
         request.body = body
-        request["Accept"] = 'application/json'
-        request["Content-Type"] = 'application/json;charset=UTF-8'
+        request['Accept'] = 'application/json'
+        request['Content-Type'] = 'application/json;charset=UTF-8'
         request['Authorization'] = "Bearer #{@access_token}"
       end
     end

--- a/lib/ince_api/reset_connectivity.rb
+++ b/lib/ince_api/reset_connectivity.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module InceApi
   class ResetConnectivity
     def initialize(access_token:, iccid:)
@@ -8,12 +10,12 @@ module InceApi
     def reset
       response = connection.request(request)
       if response.body.to_s.empty?
-        {'status_code' => 404, 'error_message' => 'SIM with ICCID not found'}
+        { 'status_code' => 404, 'error_message' => 'SIM with ICCID not found' }
       else
         JSON.parse(response.body)
       end
     rescue JSON::ParserError
-      {'status_code' => response.code.to_i, 'error_message' => "Invalid JSON response: #{response.body[0..200]}"}
+      { 'status_code' => response.code.to_i, 'error_message' => "Invalid JSON response: #{response.body[0..200]}" }
     end
 
     private
@@ -30,7 +32,7 @@ module InceApi
 
     def request
       Net::HTTP::Post.new(url).tap do |request|
-        request["Accept"] = 'application/json'
+        request['Accept'] = 'application/json'
         request['Authorization'] = "Bearer #{@access_token}"
       end
     end

--- a/lib/ince_api/reset_connectivity.rb
+++ b/lib/ince_api/reset_connectivity.rb
@@ -7,11 +7,13 @@ module InceApi
 
     def reset
       response = connection.request(request)
-      if response.body != ''
-        JSON.parse(response.body)
-      else
+      if response.body.to_s.empty?
         {'status_code' => 404, 'error_message' => 'SIM with ICCID not found'}
+      else
+        JSON.parse(response.body)
       end
+    rescue JSON::ParserError
+      {'status_code' => response.code.to_i, 'error_message' => "Invalid JSON response: #{response.body[0..200]}"}
     end
 
     private

--- a/lib/ince_api/single_sim_configuration.rb
+++ b/lib/ince_api/single_sim_configuration.rb
@@ -1,6 +1,8 @@
+# frozen_string_literal: true
+
 module InceApi
   class SingleSimConfiguration
-    def initialize(access_token:, iccid:, params:{})
+    def initialize(access_token:, iccid:, params: {})
       @access_token = access_token
       @iccid = iccid
       @params = params
@@ -8,12 +10,17 @@ module InceApi
 
     def update
       response = connection.request(request)
-      response.code.to_i == 200 ? allowed_params.merge(status: 'OK') : { status: 'FAILED', error_code: response.code.to_i}
+      if response.code.to_i == 200
+        allowed_params.merge(status: 'OK')
+      else
+        { status: 'FAILED',
+          error_code: response.code.to_i }
+      end
     end
 
     private
 
-    ALLOWED_KEYS = %i(label imei_lock status)
+    ALLOWED_KEYS = %i[label imei_lock status].freeze
     def allowed_params
       @params.slice(*ALLOWED_KEYS)
     end
@@ -31,8 +38,8 @@ module InceApi
     def request
       Net::HTTP::Put.new(url).tap do |request|
         request.body = allowed_params.to_json
-        request["Accept"] = 'application/json'
-        request["Content-Type"] = 'application/json;charset=UTF-8'
+        request['Accept'] = 'application/json'
+        request['Content-Type'] = 'application/json;charset=UTF-8'
         request['Authorization'] = "Bearer #{@access_token}"
       end
     end

--- a/spec/ince-api/create_access_token_spec.rb
+++ b/spec/ince-api/create_access_token_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe InceApi::CreateAccessToken do
@@ -29,4 +31,3 @@ RSpec.describe InceApi::CreateAccessToken do
     end
   end
 end
-

--- a/spec/ince-api/create_sms_spec.rb
+++ b/spec/ince-api/create_sms_spec.rb
@@ -1,10 +1,13 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe InceApi::CreateSms do
   it 'sends SMS to sim card' do
     VCR.use_cassette('create_sms') do
-      payload = "test SMS"
-      response = described_class.new(access_token: @token, iccid: '8988228066602306770', params: {payload: payload }).send
+      payload = 'test SMS'
+      response = described_class.new(access_token: @token, iccid: '8988228066602306770',
+                                     params: { payload: payload }).send
       expect(response[:status]).to eq 'OK'
       expect(response[:payload]).to eq payload
     end

--- a/spec/ince-api/get_sim_connectivity_spec.rb
+++ b/spec/ince-api/get_sim_connectivity_spec.rb
@@ -1,9 +1,11 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe InceApi::GetSimConnectivity do
   it 'get one sim card - idle' do
     VCR.use_cassette('get_sim_connectivity') do
-      response = described_class.new(access_token: "VALID TOKEN", iccid: '123456789').sim
+      response = described_class.new(access_token: 'VALID TOKEN', iccid: '123456789').sim
       expect(response['subscriber_info']['state']).to eq 'assumed_idle'
     end
   end

--- a/spec/ince-api/get_sim_data_quota_spec.rb
+++ b/spec/ince-api/get_sim_data_quota_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe InceApi::GetSimDataQuota do

--- a/spec/ince-api/get_sim_sms_quota_spec.rb
+++ b/spec/ince-api/get_sim_sms_quota_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe InceApi::GetSimSmsQuota do

--- a/spec/ince-api/get_sim_spec.rb
+++ b/spec/ince-api/get_sim_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe InceApi::GetSim do
@@ -12,7 +14,7 @@ RSpec.describe InceApi::GetSim do
   it 'wrond iccid' do
     VCR.use_cassette('get_sim_wrong_iccid') do
       response = described_class.new(access_token: 'VALID TOKEN', iccid: '11111222233444').sim
-      expect(response['error_message']).to eq "SIM with ICCID not found"
+      expect(response['error_message']).to eq 'SIM with ICCID not found'
       expect(response['status_code']).to eq 404
     end
   end

--- a/spec/ince-api/get_sim_status_spec.rb
+++ b/spec/ince-api/get_sim_status_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'webmock/rspec'
 
 RSpec.describe InceApi::GetSimStatus do
   it 'get one sim card status' do
@@ -8,5 +9,24 @@ RSpec.describe InceApi::GetSimStatus do
       expect(response['location']['country']['name']).to eq 'Poland'
       expect(response['location']['operator']['name']).to eq 'Plus'
     end
+  end
+
+  it 'returns error hash when API returns HTML instead of JSON' do
+    html_body = '<!doctype html><html><body>Service Unavailable</body></html>'
+    stub_request(:get, "https://api.1nce.com/management-api/v1/sims/123/status")
+      .to_return(status: 503, body: html_body, headers: {'Content-Type' => 'text/html'})
+
+    response = described_class.new(access_token: 'token', iccid: '123').sim_status
+    expect(response['status_code']).to eq 503
+    expect(response['error_message']).to start_with('Invalid JSON response:')
+  end
+
+  it 'returns 404 error hash when body is empty' do
+    stub_request(:get, "https://api.1nce.com/management-api/v1/sims/123/status")
+      .to_return(status: 200, body: '', headers: {})
+
+    response = described_class.new(access_token: 'token', iccid: '123').sim_status
+    expect(response['status_code']).to eq 404
+    expect(response['error_message']).to eq 'SIM with ICCID not found'
   end
 end

--- a/spec/ince-api/get_sim_status_spec.rb
+++ b/spec/ince-api/get_sim_status_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'webmock/rspec'
 
@@ -13,8 +15,8 @@ RSpec.describe InceApi::GetSimStatus do
 
   it 'returns error hash when API returns HTML instead of JSON' do
     html_body = '<!doctype html><html><body>Service Unavailable</body></html>'
-    stub_request(:get, "https://api.1nce.com/management-api/v1/sims/123/status")
-      .to_return(status: 503, body: html_body, headers: {'Content-Type' => 'text/html'})
+    stub_request(:get, 'https://api.1nce.com/management-api/v1/sims/123/status')
+      .to_return(status: 503, body: html_body, headers: { 'Content-Type' => 'text/html' })
 
     response = described_class.new(access_token: 'token', iccid: '123').sim_status
     expect(response['status_code']).to eq 503
@@ -22,7 +24,7 @@ RSpec.describe InceApi::GetSimStatus do
   end
 
   it 'returns 404 error hash when body is empty' do
-    stub_request(:get, "https://api.1nce.com/management-api/v1/sims/123/status")
+    stub_request(:get, 'https://api.1nce.com/management-api/v1/sims/123/status')
       .to_return(status: 200, body: '', headers: {})
 
     response = described_class.new(access_token: 'token', iccid: '123').sim_status

--- a/spec/ince-api/get_sim_usage_spec.rb
+++ b/spec/ince-api/get_sim_usage_spec.rb
@@ -1,18 +1,21 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe InceApi::GetSimUsage do
   it 'get all sim cards' do
     VCR.use_cassette('get_sim_usage') do
       response = described_class.new(access_token: 'VALID TOKEN', iccid: '8988228066602306770').sim_usage
-      expect(response["stats"].size).to eq 15
-      expect(response['stats'].first['date']).to eq "2021-11-14"
+      expect(response['stats'].size).to eq 15
+      expect(response['stats'].first['date']).to eq '2021-11-14'
       expect(response['stats'].first['data']['volume']).to eq '0'
     end
   end
 
   xit 'get sim usage with params' do
     VCR.use_cassette('get_sims_usage_with_params') do
-      response = described_class.new(access_token: @token, iccid: '8988228066602306770', params: {start_dt: 2021-11-10, end_dt: 2021-11-12}).sim_usage
+      described_class.new(access_token: @token, iccid: '8988228066602306770',
+                          params: { start_dt: 2021 - 11 - 10, end_dt: 2021 - 11 - 12 }).sim_usage
     end
   end
 end

--- a/spec/ince-api/get_sims_spec.rb
+++ b/spec/ince-api/get_sims_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe InceApi::GetSims do
@@ -11,19 +13,19 @@ RSpec.describe InceApi::GetSims do
 
   it 'get sim cards with params' do
     VCR.use_cassette('get_sims_with_params') do
-      response = described_class.new(access_token: 'VALID TOKEN', params: {page: 2, pageSize: 5}).sims
+      response = described_class.new(access_token: 'VALID TOKEN', params: { page: 2, pageSize: 5 }).sims
       expect(response.size).to eq 5
     end
   end
 
   it 'paginates results' do
-   VCR.use_cassette('get_sims_with_params_page_1') do
-      @response_p1 = described_class.new(access_token: 'VALID TOKEN', params: {page: 1, pageSize: 5}).sims
+    VCR.use_cassette('get_sims_with_params_page_1') do
+      @response_p1 = described_class.new(access_token: 'VALID TOKEN', params: { page: 1, pageSize: 5 }).sims
       expect(@response_p1.size).to eq 5
     end
 
     VCR.use_cassette('get_sims_with_params') do
-      @response_p2 = described_class.new(access_token: 'VALID TOKEN', params: {page: 2, pageSize: 5}).sims
+      @response_p2 = described_class.new(access_token: 'VALID TOKEN', params: { page: 2, pageSize: 5 }).sims
       expect(@response_p2.size).to eq 5
     end
 
@@ -32,7 +34,7 @@ RSpec.describe InceApi::GetSims do
 
   it 'returns headers too' do
     VCR.use_cassette('get_sims_with_params') do
-      service = described_class.new(access_token: 'VALID TOKEN', params: {page: 2, pageSize: 5})
+      service = described_class.new(access_token: 'VALID TOKEN', params: { page: 2, pageSize: 5 })
       response = service.sims
       headers = service.headers
       expect(response.size).to eq 5

--- a/spec/ince-api/multiple_sims_configuration_spec.rb
+++ b/spec/ince-api/multiple_sims_configuration_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe InceApi::MultipleSimsConfiguration do
@@ -10,7 +12,8 @@ RSpec.describe InceApi::MultipleSimsConfiguration do
 
   it 'updates one sim card - changes' do
     VCR.use_cassette('update_sims_label_change') do
-      params = [{iccid: '8988228066602306711', label: 'Test Label 1'}, {iccid: '8988228066602307111', label: 'Test Label 2'}]
+      params = [{ iccid: '8988228066602306711', label: 'Test Label 1' },
+                { iccid: '8988228066602307111', label: 'Test Label 2' }]
       response = described_class.new(access_token: 'VALID TOKEN', changes_array: params).update_many
       expect(response[:status]).to eq 'OK'
     end

--- a/spec/ince-api/single_sim_configuration_spec.rb
+++ b/spec/ince-api/single_sim_configuration_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe InceApi::SingleSimConfiguration do
@@ -10,7 +12,8 @@ RSpec.describe InceApi::SingleSimConfiguration do
 
   it 'updates one sim card - changes' do
     VCR.use_cassette('update_sim_label_change') do
-      response = described_class.new(access_token: 'VALID TOKEN', iccid: '8988228066602306770', params: {label: 'Test Label'}).update
+      response = described_class.new(access_token: 'VALID TOKEN', iccid: '8988228066602306770',
+                                     params: { label: 'Test Label' }).update
       expect(response[:status]).to eq 'OK'
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,8 +1,10 @@
+# frozen_string_literal: true
+
 require 'ince-api'
 require 'vcr'
 
 VCR.configure do |config|
-  config.cassette_library_dir = "spec/fixtures/vcr_cassettes"
+  config.cassette_library_dir = 'spec/fixtures/vcr_cassettes'
   config.hook_into :webmock
 end
 
@@ -17,4 +19,3 @@ RSpec.configure do |config|
 
   config.shared_context_metadata_behavior = :apply_to_host_groups
 end
-


### PR DESCRIPTION
## Summary
- Rescue `JSON::ParserError` in all 9 API classes that parse responses
- Return consistent error hash (`status_code` + `error_message` with truncated body) instead of raising
- Triggered by production Rollbar #619: 1nce API returned `<!doctype html>` (likely CDN 503 page)
- Verified against 1nce OpenAPI spec — error responses (401/403/404/422) document empty content, HTML is undocumented CDN behavior
- Bump version to 0.3.1

## Test plan
- [x] Added 2 new specs for GetSimStatus (HTML response + empty body)
- [x] Full suite passes (24 examples, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)